### PR TITLE
update ruapu

### DIFF
--- a/src/libllm/cpu/kernel/kernel.cc
+++ b/src/libllm/cpu/kernel/kernel.cc
@@ -44,7 +44,7 @@ enum class CPUMathBackend {
 };
 
 CPUMathBackend findBestCpuMathBackend() {
-  raupu_init();
+  ruapu_init();
   bool isaAvx2 = ruapu_supports("avx2") > 0;
   bool isaAvx512f = ruapu_supports("avx512f") > 0;
   bool isaF16c = ruapu_supports("f16c") > 0;


### PR DESCRIPTION
- for the issue https://github.com/ling0322/libllm/pull/42
- based on upstream ruapu commit: 2d3681e 2024-02-22 | risc-v support (#19)
- mainly for two purpose: 
    - API renaming: `raupu_init()` -> `ruapu_init()`
    - bug fix of avxvnni, avxifma detection